### PR TITLE
Fix latest release can't be built

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,13 +6,13 @@
         "modules": false,
         "useBuiltIns": "entry",
         "corejs": 3,
+        "shippedProposals": true
       }
     ],
     "@babel/preset-react"
   ],
   "plugins": [
     ["styled-components", { "displayName": true }],
-    "@babel/plugin-proposal-class-properties"
   ],
   "env": {
     "test": {


### PR DESCRIPTION
Closes #2

Following @sembrestels advice, [this](https://github.com/1Hive/transactions-app/commit/a6721f34c8ad099e32d94b20dd6a528ec5d09ef9#diff-a172cedcae47474b615c54d510a5d84a8dea3032e958587430b413538be3f333) fixed it :tada: 