### PR TITLE
Support multichain

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -45,7 +45,6 @@ const INITIAL_DAO_STATE = {
   repos: [],
 }
 
-
 const SELECTOR_NETWORKS = [
   ['xdai', 'xDai Network', 'https://aragon.1hive.org/'],
   ['polygon', 'Polygon Network', 'https://aragon.1hive.org/'],

--- a/src/local-settings.js
+++ b/src/local-settings.js
@@ -118,6 +118,10 @@ export function getEthNetworkType() {
   return getLocalSetting(ETH_NETWORK_TYPE) || 'rinkeby'
 }
 
+export function setEthNetworkType(networkType) {
+  return setLocalSetting(ETH_NETWORK_TYPE, networkType)
+}
+
 export function getEthSubscriptionEventDelay() {
   const delay = parseInt(getLocalSetting(ETH_SUBSCRIPTION_EVENT_DELAY), 10)
   return Number.isFinite(delay) ? delay : 0

--- a/src/network-config.js
+++ b/src/network-config.js
@@ -105,7 +105,7 @@ export const networkConfigs = {
       chainId: 100,
       name: 'xDai',
       shortName: 'xdai',
-      type: 'private',
+      type: 'xdai',
       live: true,
     },
     providers: [
@@ -126,7 +126,7 @@ export const networkConfigs = {
       chainId: 137,
       name: 'Polygon',
       shortName: 'polygon',
-      type: 'private',
+      type: 'polygon',
       live: true,
     },
     providers: [

--- a/src/onboarding/Welcome/Welcome.js
+++ b/src/onboarding/Welcome/Welcome.js
@@ -7,6 +7,7 @@ import Header from '../Header/Header'
 import OpenOrg from './OpenOrg'
 import Suggestions from './Suggestions'
 import WelcomeAction from './WelcomeAction'
+import { setEthNetworkType } from '../../local-settings'
 
 import actionCreate from './assets/action-create.png'
 import actionOpen from './assets/action-open.png'
@@ -34,6 +35,7 @@ const Welcome = React.memo(function Welcome({
 
   const changeNetwork = useCallback(
     index => {
+      setEthNetworkType(selectorNetworksSorted[index].type)
       window.location = selectorNetworksSorted[index].url
     },
     [selectorNetworksSorted]


### PR DESCRIPTION
Saves network type on local storage after selecting the network on the Welcome's dropdown.

Note that this will be only relevant for xdai and polygon networks as mainnet and rinkeby are deployed in different urls.