### PR TITLE
Rollback network type

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -46,10 +46,11 @@ const INITIAL_DAO_STATE = {
 }
 
 const SELECTOR_NETWORKS = [
-  ['xdai', 'xDai Network', 'https://aragon.1hive.org/'],
-  ['polygon', 'Polygon Network', 'https://aragon.1hive.org/'],
-  ['main', 'Ethereum Mainnet', 'https://client.aragon.org/'],
+  [100, 'xdai', 'xDai Network', 'https://aragon.1hive.org/'],
+  [137, 'polygon', 'Polygon Network', 'https://aragon.1hive.org/'],
+  [1, 'main', 'Ethereum Mainnet', 'https://client.aragon.org/'],
   [
+    4,
     'rinkeby',
     'Ethereum Testnet (Rinkeby)',
     'https://rinkeby.client.aragon.org/',

--- a/src/network-config.js
+++ b/src/network-config.js
@@ -105,7 +105,7 @@ export const networkConfigs = {
       chainId: 100,
       name: 'xDai',
       shortName: 'xdai',
-      type: 'xdai',
+      type: 'private',
       live: true,
     },
     providers: [
@@ -126,7 +126,7 @@ export const networkConfigs = {
       chainId: 137,
       name: 'Polygon',
       shortName: 'polygon',
-      type: 'polygon',
+      type: 'private',
       live: true,
     },
     providers: [

--- a/src/onboarding/Welcome/Welcome.js
+++ b/src/onboarding/Welcome/Welcome.js
@@ -25,10 +25,10 @@ const Welcome = React.memo(function Welcome({
 
   const selectorNetworksSorted = useMemo(() => {
     return selectorNetworks
-      .map(([type, name, url]) => ({ type, name, url }))
+      .map(([chainId, type, name, url]) => ({ chainId, type, name, url }))
       .sort((a, b) => {
-        if (b.type === network.type) return 1
-        if (a.type === network.type) return -1
+        if (b.chainId === network.chainId) return 1
+        if (a.chainId === network.chainId) return -1
         return 0
       })
   }, [selectorNetworks])


### PR DESCRIPTION
- Rolls back network type change made from `private` to `xdai/polygon` This is because the SignerPanel validates that the network type from wallet and network config are the same. And wallet network type is always `private` for xdai and polygon.